### PR TITLE
use observer to create export button

### DIFF
--- a/chrome-extension/calendar/calendar.js
+++ b/chrome-extension/calendar/calendar.js
@@ -623,4 +623,13 @@ const buttonBody = async () => {
   // console.log(createRecurringVEVENT(c, []))
 }
 
-setTimeout(appendButton, 10000); //Wait 5 seconds after load before applying button. There has to be a better way 
+const appObserver = new MutationObserver((mutations) => {
+  const look = document.querySelector("div[class='myu_btn-group col-lg-12']")
+  if (look) {
+    if (look.parentNode.children.length < 4) {
+      appendButton()
+    }
+  }
+});
+
+appObserver.observe(document.body, {childList: true, subtree: true});


### PR DESCRIPTION
this change basically takes from sidebar.js the observer which allows the extension to receive mutation events and respond to changes to the DOM. the button will now be loaded as soon as the calendar is loaded.