### PR TITLE
Add JSON export functionality, parsing and scraping improvements

### DIFF
--- a/chrome-extension/calendar/calendar.js
+++ b/chrome-extension/calendar/calendar.js
@@ -751,4 +751,13 @@ const buttonBody = async () => {
   // console.log(createRecurringVEVENT(c, []))
 }
 
-setTimeout(appendButton, 5000); //Wait 5 seconds after load before applying button. There has to be a better way 
+const appObserver = new MutationObserver((mutations) => {
+  const look = document.querySelector("div[class='myu_btn-group col-lg-12']")
+  if (look) {
+    if (look.parentNode.children.length < 4) {
+      appendButton()
+    }
+  }
+});
+
+appObserver.observe(document.body, {childList: true, subtree: true});

--- a/chrome-extension/calendar/calendar.js
+++ b/chrome-extension/calendar/calendar.js
@@ -345,63 +345,63 @@ const scraperSecondPass = (weeks, coursesInfo) => {
 }
 
   
-    // BEGIN ZONE OF EXTRA JANK
-  
-    // Scraping up all meeting times, including catching when classes are canceled for holidays
-    // General game plan: 
-    // 1. pick a sample week (which week best to pick?), then grab all the course numbers in it
-    // 2. Then get the general course info for each of those course numbers, store it somewhere
-    // 3. Then take one of the `dateRange`s (they're all the same) and scrape through the whole thing to find instances of when a class should appear but it doesn't. store this somehow
-    console.log("scraper.js runs!")
-  
-    /**
-     * Given a date, returns info on each course meeting in the semester containing that date. Also returns generally-true info about the courses in the semester
-     * @param {string} [sampleDateString="today"] // format: "yyyy-mm-dd". Note: this should be a *representative week of the semester*, not breaktime
-     * @returns {Object} // has fields `.weeks` and `.coursesInfo`
-     * `.weeks` is a doubly-nested array of every single class meeting in the semester
-     * `.coursesInfo` is the general course info (e.g. term start and end days) for each class *found in the sample week*
-     */
-    const scrapeASemester = async (sampleDateString="today") => {
-      // NOTE: sampleWeek is just an array of meeting objects
-      let sampleWeek = (await weekToJson(sampleDateString)).meetingObjects // samples from the sample week
-      let term = sampleWeek[0].term // extracts term. we'll need this later
-      let institution = sampleWeek[0].institution
-  
-      let courseNums = []
-      for (let i = 0; i < sampleWeek.length; i++) {
-        if (!courseNums.includes(sampleWeek[i].courseNum)) {
-          courseNums.push(sampleWeek[i].courseNum)
-        }
-      }
-  
-      // 2. 
-      let coursesInfo = [] // list containing general class info for all the courses you're enrolled in
-      for (let courseNum of courseNums) {
-        coursesInfo.push(await generalClassInfo(term, courseNum, institution))
-      }
-  
-      // 3: loop through week by week and do ...stuff
-      startDate = endDate = coursesInfo[0].dateRange[0]
-      endDate = coursesInfo[0].dateRange[1]
-      endDate.setDate(endDate.getDate() + 7) // pad an extra week onto endDate so we can be sure we got everything
-  
-      // for loop from startDate to endDate. step size is one week
-      // `date` is a date lying in the week of interest
-      let weeks = []
-      for (let date = new Date(startDate.getTime()); date <= endDate; date.setDate(date.getDate() + 7)) { // the reason we need to pad endDate
-        let currentWeekData = await weekToJson(formatDate(date, "yyyy-mm-dd"))
-        // now um somehow check for when a class should be happening, but isn't (e.g. break/holiday)
-        // ??? think about this later
-        weeks.push(currentWeekData)
-      }
-  
-      // soup up `coursesInfo` by pulling data out of `weeks`.
+// BEGIN ZONE OF EXTRA JANK
+
+// Scraping up all meeting times, including catching when classes are canceled for holidays
+// General game plan: 
+// 1. pick a sample week (which week best to pick?), then grab all the course numbers in it
+// 2. Then get the general course info for each of those course numbers, store it somewhere
+// 3. Then take one of the `dateRange`s (they're all the same) and scrape through the whole thing to find instances of when a class should appear but it doesn't. store this somehow
+console.log("scraper.js runs!")
+
+/**
+ * Given a date, returns info on each course meeting in the semester containing that date. Also returns generally-true info about the courses in the semester
+ * @param {string} [sampleDateString="today"] // format: "yyyy-mm-dd". Note: this should be a *representative week of the semester*, not breaktime
+ * @returns {Object} // has fields `.weeks` and `.coursesInfo`
+ * `.weeks` is a doubly-nested array of every single class meeting in the semester
+ * `.coursesInfo` is the general course info (e.g. term start and end days) for each class *found in the sample week*
+ */
+const scrapeASemester = async (sampleDateString="today") => {
+  // NOTE: sampleWeek is just an array of meeting objects
+  let sampleWeek = (await weekToJson(sampleDateString)).meetingObjects // samples from the sample week
+  let term = sampleWeek[0].term // extracts term. we'll need this later
+  let institution = sampleWeek[0].institution
+
+  let courseNums = []
+  for (let i = 0; i < sampleWeek.length; i++) {
+    if (!courseNums.includes(sampleWeek[i].courseNum)) {
+      courseNums.push(sampleWeek[i].courseNum)
+    }
+  }
+
+  // 2. 
+  let coursesInfo = [] // list containing general class info for all the courses you're enrolled in
+  for (let courseNum of courseNums) {
+    coursesInfo.push(await generalClassInfo(term, courseNum, institution))
+  }
+
+  // 3: loop through week by week and do ...stuff
+  startDate = endDate = coursesInfo[0].dateRange[0]
+  endDate = coursesInfo[0].dateRange[1]
+  endDate.setDate(endDate.getDate() + 7) // pad an extra week onto endDate so we can be sure we got everything
+
+  // for loop from startDate to endDate. step size is one week
+  // `date` is a date lying in the week of interest
+  let weeks = []
+  for (let date = new Date(startDate.getTime()); date <= endDate; date.setDate(date.getDate() + 7)) { // the reason we need to pad endDate
+    let currentWeekData = await weekToJson(formatDate(date, "yyyy-mm-dd"))
+    // now um somehow check for when a class should be happening, but isn't (e.g. break/holiday)
+    // ??? think about this later
+    weeks.push(currentWeekData)
+  }
+
+  // soup up `coursesInfo` by pulling data out of `weeks`.
   let additionalMeetings = scraperSecondPass(weeks, coursesInfo)
   
   return ({ "weeks" : weeks,
             "coursesInfo" : coursesInfo,
             "additionalMeetings" : additionalMeetings}) // {Array<Meeting Objects>}
-  }
+}
   
 // ##########
 // End scraper.js

--- a/chrome-extension/calendar/calendar.js
+++ b/chrome-extension/calendar/calendar.js
@@ -122,7 +122,7 @@ let formatDaysOfWeek = (daysOfWeek) => {
  * @param {string} [dateString="today"] // a day during the week in question (Let's say the Sunday.), in format "yyyy-mm-dd", WITH DASHES. "today" gives the current week
  * @returns {Object} weekObject
  */
-const weekToJson = async (dateString="today") => {
+const weekToJSON = async (dateString="today") => {
   if (dateString == "today") {
     dateString = formatDate(new Date(), "yyyy-mm-dd")
   }
@@ -137,6 +137,10 @@ const weekToJson = async (dateString="today") => {
     
   // parsing begins
   var synchronousMeetings = el.querySelector(".myu_calendar") // HTML div containing only the classes with set days and times
+  if (synchronousMeetings == null) {
+    console.log(`encountered a week without meetings (${dateString}).`)
+    return {"meetingObjects" : [], "sundayDate" : sundayThisWeek(parseDate(dateString, "yyyy-mm-dd"))}
+  }
   var meetingElements = synchronousMeetings.querySelectorAll(".myu_calendar-class") // list of all the classes this week as HTML elems
   const meetingObjects = []; // list of json objects holding meeting data
   for (let meetingEl of meetingElements) {
@@ -363,7 +367,7 @@ console.log("scraper.js runs!")
  */
 const scrapeASemester = async (sampleDateString="today") => {
   // NOTE: sampleWeek is just an array of meeting objects
-  let sampleWeek = (await weekToJson(sampleDateString)).meetingObjects // samples from the sample week
+  let sampleWeek = (await weekToJSON(sampleDateString)).meetingObjects // samples from the sample week
   let term = sampleWeek[0].term // extracts term. we'll need this later
   let institution = sampleWeek[0].institution
 
@@ -389,7 +393,7 @@ const scrapeASemester = async (sampleDateString="today") => {
   // `date` is a date lying in the week of interest
   let weeks = []
   for (let date = new Date(startDate.getTime()); date <= endDate; date.setDate(date.getDate() + 7)) { // the reason we need to pad endDate
-    let currentWeekData = await weekToJson(formatDate(date, "yyyy-mm-dd"))
+    let currentWeekData = await weekToJSON(formatDate(date, "yyyy-mm-dd"))
     // now um somehow check for when a class should be happening, but isn't (e.g. break/holiday)
     // ??? think about this later
     weeks.push(currentWeekData)


### PR DESCRIPTION
Summary of changes:
- Added the `dataToExportJSON()` function, which allows scraped data to be exported in JSON format (for use in Google Calendar API stuff or something, ask Samyok)
- `scrapeASemester()` should now work at campuses other than just UMNTC
- Regex now properly reads Saturday and Sunday classes, so they should now load seamlessly into the calendar as well
- Added support for "additional/outlier meetings", i.e. if your class has an extra meeting one week (e.g. an exam), it should now be reflected in the calendar (assuming the meeting is in MyU)
- Refactored and cleaned up data-parsing code a little bit, added documentation to functions
- Tested scraping and exporting on a few different schedules, fixed a few bugs, (e.g. code erroring out if the schedule's weird; an issue with the `.ics` file where all of the courses are present on the first day of class, even if it's not their correct day)