### PR TITLE
responsive rmp star rating

### DIFF
--- a/frontend/components/distributionsToCards.jsx
+++ b/frontend/components/distributionsToCards.jsx
@@ -11,7 +11,6 @@ import {
   Text,
   Tooltip,
   useDisclosure,
-  useMediaQuery,
   VStack,
 } from "@chakra-ui/react";
 import React from "react";
@@ -91,27 +90,27 @@ const SingleDistribution = ({ dist, isMobile, isStatic }) => {
             )}
             <HStack pt={3}>
               {dist.rating && (
-                  <Tooltip label={"RateMyProfessor rating"} hasArrow>
-                      <Tag
-                        size={"sm"}
-                        variant={"outline"}
-                        textAlign={"center"}
-                        colorScheme={RMPToColor(dist.rating)}
-                        py={1}
-                      >
-                        {dist.rating.toFixed(1)}
-                        <Show breakpoint='(min-width: 450px)'>
-                          <chakra.span pl={1} mt={-0.5}>
-                            {Array(Math.round(dist.rating)).fill(<StarIcon />)}
-                          </chakra.span>
-                        </Show>
-                        <Hide breakpoint='(min-width: 450px)'>
-                        <chakra.span pl={1} mt={-0.5}>
-                            <StarIcon />
-                          </chakra.span>
-                        </Hide>
-                      </Tag>
-                  </Tooltip>
+                <Tooltip label={"RateMyProfessor rating"} hasArrow>
+                  <Tag
+                    size={"sm"}
+                    variant={"outline"}
+                    textAlign={"center"}
+                    colorScheme={RMPToColor(dist.rating)}
+                    py={1}
+                  >
+                    {dist.rating.toFixed(1)}
+                    <Show breakpoint={"(min-width: 450px)"}>
+                      <chakra.span pl={1} mt={-0.5}>
+                        {Array(Math.round(dist.rating)).fill(<StarIcon />)}
+                      </chakra.span>
+                    </Show>
+                    <Hide breakpoint={"(min-width: 450px)"}>
+                      <chakra.span pl={1} mt={-0.5}>
+                        <StarIcon />
+                      </chakra.span>
+                    </Hide>
+                  </Tag>
+                </Tooltip>
               )}
 
               {dist.averageGPA > 0 && (

--- a/frontend/components/distributionsToCards.jsx
+++ b/frontend/components/distributionsToCards.jsx
@@ -3,12 +3,15 @@ import {
   Box,
   chakra,
   Collapse,
+  Hide,
   HStack,
   IconButton,
+  Show,
   Tag,
   Text,
   Tooltip,
   useDisclosure,
+  useMediaQuery,
   VStack,
 } from "@chakra-ui/react";
 import React from "react";
@@ -33,6 +36,7 @@ const sortingFunctions = {
 
 const SingleDistribution = ({ dist, isMobile, isStatic }) => {
   const { isOpen, onToggle } = useDisclosure();
+  const [smallerThan450] = useMediaQuery('(max-width: 450px)')
   const title = dist.title ?? "Unknown";
   let { subtitle } = dist;
   if (!subtitle && dist.terms?.length > 1) {
@@ -88,20 +92,27 @@ const SingleDistribution = ({ dist, isMobile, isStatic }) => {
             )}
             <HStack pt={3}>
               {dist.rating && (
-                <Tooltip label={"RateMyProfessor rating"} hasArrow>
-                  <Tag
-                    size={"sm"}
-                    variant={"outline"}
-                    textAlign={"center"}
-                    colorScheme={RMPToColor(dist.rating)}
-                    py={1}
-                  >
-                    {dist.rating.toFixed(1)}
-                    <chakra.span pl={1} mt={-0.5}>
-                      {Array(Math.round(dist.rating)).fill(<StarIcon />)}
-                    </chakra.span>
-                  </Tag>
-                </Tooltip>
+                  <Tooltip label={"RateMyProfessor rating"} hasArrow>
+                      <Tag
+                        size={"sm"}
+                        variant={"outline"}
+                        textAlign={"center"}
+                        colorScheme={RMPToColor(dist.rating)}
+                        py={1}
+                      >
+                        {dist.rating.toFixed(1)}
+                        <Show breakpoint='(min-width: 450px)'>
+                          <chakra.span pl={1} mt={-0.5}>
+                            {Array(Math.round(dist.rating)).fill(<StarIcon />)}
+                          </chakra.span>
+                        </Show>
+                        <Hide breakpoint='(min-width: 450px)'>
+                        <chakra.span pl={1} mt={-0.5}>
+                            <StarIcon />
+                          </chakra.span>
+                        </Hide>
+                      </Tag>
+                  </Tooltip>
               )}
 
               {dist.averageGPA > 0 && (

--- a/frontend/components/distributionsToCards.jsx
+++ b/frontend/components/distributionsToCards.jsx
@@ -36,7 +36,6 @@ const sortingFunctions = {
 
 const SingleDistribution = ({ dist, isMobile, isStatic }) => {
   const { isOpen, onToggle } = useDisclosure();
-  const [smallerThan450] = useMediaQuery('(max-width: 450px)')
   const title = dist.title ?? "Unknown";
   let { subtitle } = dist;
   if (!subtitle && dist.terms?.length > 1) {


### PR DESCRIPTION
fixes #96 

on low width screen (here i chose 450px), it only shows one star by default. this was the easiest fix i could come up with, I tried making the stars sit under the text but it resulted in a much bigger change in structure than i felt was necessary for a small fix