### PR TITLE
Change calendar storage location for a looser byte quota

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -45,7 +45,7 @@ chrome.action.onClicked.addListener((tab) => {
 
 const RuntimeMessages = {
   openCalendarTab: async (request) => {
-    await chrome.storage.sync.set({ cal: request.data });
+    await chrome.storage.local.set({ cal: request.data });
 
     await chrome.tabs.create({
       url: chrome.runtime.getURL("frontend/gcal/add.html"),

--- a/chrome-extension/frontend/gcal/add.js
+++ b/chrome-extension/frontend/gcal/add.js
@@ -61,7 +61,7 @@ const unifyClasses = (classes) => {
 };
 
 let cal;
-chrome.storage.sync.get(["cal"], (result) => {
+chrome.storage.local.get(["cal"], (result) => {
   cal = result.cal;
   console.log(cal);
 
@@ -326,7 +326,7 @@ document.querySelector("#add").addEventListener("click", async (e) => {
 });
 
 document.querySelector("#ics").addEventListener("click", async (e) => {
-  blob = portableToIcsBlob(cal)
+  blob = portableToIcsBlob(cal);
   console.log(blob);
   fileDownload(blob);
 });

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Gopher Grades - Past grades for UMN classes!",
   "description": "Now you can view directly from the course catalog!",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 3,
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
This PR fixes a small (though sometimes breaking) bug: when we pass calendar data to the Add to Calendar tab via `chrome.storage.sync.set(...)`, we may exceed `storage.sync`'s 8 kB `QUOTA_BYTES_PER_ITEM` limit (especially if a course has additional meetings). Fix is simple, though: use `storage.local` instead. 