### PR TITLE
Fix plotter not loading due to dependency on sidebar.js

### DIFF
--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -16,21 +16,11 @@
         "https://*.schedulebuilder.umn.edu/*"
       ],
       "css": [
-        "sidebar/sidebar.css"
-      ],
-      "js": [
-        "sidebar/sidebar.js"
-      ]
-    },
-    {
-      "matches": [
-        "https://schedulebuilder.umn.edu/*",
-        "https://*.schedulebuilder.umn.edu/*"
-      ],
-      "css": [
+        "sidebar/sidebar.css",
         "plotter/plotter.css"
       ],
       "js": [
+        "sidebar/sidebar.js",
         "plotter/apiapi.js",
         "plotter/util.js",
         "plotter/main.js"


### PR DESCRIPTION
I noticed that the map was not working and found that sidebar.js was not loading before plotter/*.js, which plotter/main.js needs to use htmlToElement. It seems this is due to sidebar.js and main.js being in separate "content_scripts" entries (which I did...) and the order in which they appear does not indicate the order in which they are evaluated. While I have not been able to reproduce this error since reinstalling (without the fix), the order in which "js" entries are loaded is well-defined, so this PR reverts the change I made (which seems to have solved the issue).

I'm pretty sure I should either not be using htmlToElement in the first place, or the plotter UI should be more integrated into the "Schedule Builder" portion of the extension (and reorganized accordingly).