### PR TITLE
Search bar quality of life improvements

### DIFF
--- a/frontend/components/Search/SearchBar.jsx
+++ b/frontend/components/Search/SearchBar.jsx
@@ -1,12 +1,20 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { Input, InputGroup, InputLeftElement } from "@chakra-ui/react";
 import { Search2Icon } from "@chakra-ui/icons";
 
 const SearchBar = ({
   onChange,
   placeholder = "Search by Class, Instructor, or Department",
+  autofocus = false,
 }) => {
   const [search, setSearch] = useState("");
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    if (autofocus) {
+      inputRef.current?.focus();
+    }
+  }, [autofocus]);
 
   const handleChange = (e) => {
     setSearch(e.target.value);
@@ -19,6 +27,7 @@ const SearchBar = ({
         <Search2Icon color={"black"} />
       </InputLeftElement>
       <Input
+        ref={inputRef}
         type={"text"}
         value={search}
         onChange={handleChange}

--- a/frontend/components/Search/SearchBar.jsx
+++ b/frontend/components/Search/SearchBar.jsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useRef } from "react";
 import { Input, InputGroup, InputLeftElement } from "@chakra-ui/react";
 import { Search2Icon } from "@chakra-ui/icons";
+import { useSearchFocus } from "./useSearchFocus";
 
 const SearchBar = ({
   onChange,
@@ -10,11 +11,7 @@ const SearchBar = ({
   const [search, setSearch] = useState("");
   const inputRef = useRef(null);
 
-  useEffect(() => {
-    if (autofocus) {
-      inputRef.current?.focus();
-    }
-  }, [autofocus]);
+  useSearchFocus(inputRef, autofocus);
 
   const handleChange = (e) => {
     setSearch(e.target.value);

--- a/frontend/components/Search/useSearchFocus.jsx
+++ b/frontend/components/Search/useSearchFocus.jsx
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+import { useToast } from "@chakra-ui/react";
+
+export const useSearchFocus = (inputRef, autofocus = false) => {
+  const toast = useToast();
+  useEffect(() => {
+    if (autofocus) {
+      inputRef.current?.focus();
+    }
+  }, [autofocus, inputRef]);
+
+  useEffect(() => {
+    let toastShown = false;
+    const handleKeyDown = (e) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const active = document.activeElement;
+      const isTyping =
+        active &&
+        (active.tagName === "INPUT" ||
+          active.tagName === "TEXTAREA" ||
+          active.isContentEditable);
+      if (isTyping) return;
+
+      if (e.key === "/") {
+        e.preventDefault();
+        inputRef.current?.focus();
+        return;
+      }
+
+      const isAlphanumeric = e.key.length === 1 && /[a-zA-Z0-9]/.test(e.key);
+      if (isAlphanumeric && !toastShown) {
+        toastShown = true;
+
+        toast({
+          title: 'Press "/" to search',
+          status: "info",
+          duration: 5000,
+          variant: "subtle",
+          isClosable: true,
+          position: "bottom-right",
+          containerStyle: {
+            color: "#3182ce",
+          },
+        });
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [inputRef, toast]);
+}

--- a/frontend/components/Search/useSearchFocus.jsx
+++ b/frontend/components/Search/useSearchFocus.jsx
@@ -51,4 +51,4 @@ export const useSearchFocus = (inputRef, autofocus = false) => {
       window.removeEventListener("keydown", handleKeyDown);
     };
   }, [inputRef, toast]);
-}
+};

--- a/frontend/pages/index.jsx
+++ b/frontend/pages/index.jsx
@@ -83,6 +83,7 @@ const Home = () => {
             <SearchBar
               placeholder={search || undefined}
               onChange={handleChange}
+              autofocus
             />
           </Box>
           <Collapse in={showPage} animateOpacity>


### PR DESCRIPTION
Not an open issue but I thought the search bar could benefit from a few UX tweaks:
- Autofocus on page load
- Quick shortcut to jump to search box when needed

## Autofocus
Added functionality so that the search box is focused on page load so that users can start searching without having to make an additional click. This feels normal for a website that is based around search. The default html `autofocus` attribute does not work, probably due to some timing issue with react, next js and how it gets loaded to DOM. That is why the complicated useRef workaround was used. Happy to consider feedback on how to improve this. 

Initially I made it autofocus on every page load; however, it looked odd on pages other than the home page with its halo around the borders when focused. So, the autofocus prop was added to only focus the search bar on the home page. If needed, we can change this to happen on all pages.

## The `/` jump shortcut
Added a quick way to jump to the search box by pressing `/`. This is expected behavior on most search based sites. Also added a quick toast like google to signal the existence of this feature to someone typing without focusing on the search box.